### PR TITLE
Fix a typo in rseqc.yaml

### DIFF
--- a/envs/rseqc.yaml
+++ b/envs/rseqc.yaml
@@ -1,4 +1,4 @@
-hannels:
+channels:
   - conda-forge
   - bioconda
 dependencies:


### PR DESCRIPTION
There was a small typo ("hannels" instead of "channels")